### PR TITLE
Fixed mobile height, changed icon to chart

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,0 +1,11 @@
+.plausible-iframe {
+  width: 1px;
+  min-width: 100%;
+  height: 1700px;
+}
+
+@media (max-width: 850px) {
+  .plausible-iframe {
+    height: 2300px;
+  }
+}

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ panel.plugin("floriankarsten/plausible", {
 			template: `
 				<k-inside>
 					<k-view class="k-plausible-view">
-						<iframe v-if="sharedLink" plausible-embed v-bind:src="sharedLink + '&embed=true&theme=light&background=%23efefef'" scrolling="no" frameborder="0" loading="lazy" style="width: 1px; min-width: 100%; height: 1600px;"></iframe>
+						<iframe v-if="sharedLink" plausible-embed v-bind:src="sharedLink + '&embed=true&theme=light&background=%23efefef'" scrolling="no" frameborder="0" loading="lazy" class="plausible-iframe"></iframe>
 						<div style="margin-top: 30px; text-align: center;" v-else>
 							<code>You need to set floriankarsten.plausible.sharedLink in config.php</code>
 						</div>

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@ Kirby::plugin('floriankarsten/plausible', [
 		'plausible' => function ($kirby) {
 			return [
 				'label' => 'Analytics',
-				'icon' => 'account',
+				'icon' => 'chart',
 				'disabled' => false,
 				'menu' => true,
 				'link' => 'plausible',


### PR DESCRIPTION
![wa](https://user-images.githubusercontent.com/7975568/190355751-3a6432fa-5d7c-4dd2-a389-6690b6597dc7.png)

I changed the icon of the panel view to `chart` which is a better fit. Especially next to the actual account view right underneath.

I also added a media query to increase the height of the iframe on mobile devices because it was cut off. Ideally we could dynamically update the height but I couldn't get that to work because of CORS issues.